### PR TITLE
Merge unicode-org:maint/maint-67 into units-staging.

### DIFF
--- a/icu4c/source/test/intltest/measfmttest.cpp
+++ b/icu4c/source/test/intltest/measfmttest.cpp
@@ -3427,7 +3427,9 @@ void MeasureFormatTest::TestIdentifiers() {
         const char* id;
         const char* normalized;
     } cases[] = {
-        { true, "square-meter-per-square-meter", "square-meter-per-square-meter" },
+        {true, "square-meter-per-square-meter", "square-meter-per-square-meter"},
+        {true, "kilogram-meter-per-square-meter-square-second",
+         "kilogram-meter-per-square-meter-square-second"},
         // TODO(ICU-20920): Add more test cases once the proper ranking is available.
     };
     for (const auto& cas : cases) {


### PR DESCRIPTION
This would pick up the ICU-21060 fix that is hindering one of the unitsTest.txt test cases.

It is aligned with the strategy of occasionally merging the upstream master branch into units-staging.
