### PR TITLE
Change getPreferencesFor parameters from char* to StringPiece.

### DIFF
--- a/icu4c/source/i18n/unitsdata.cpp
+++ b/icu4c/source/i18n/unitsdata.cpp
@@ -107,8 +107,8 @@ class ConversionRateDataSink : public ResourceSink {
     MaybeStackVector<ConversionRateInfo> *outVector;
 };
 
-UnitPreferenceMetadata::UnitPreferenceMetadata(const StringPiece category, const StringPiece usage,
-                                               const StringPiece region, int32_t prefsOffset,
+UnitPreferenceMetadata::UnitPreferenceMetadata(StringPiece category, StringPiece usage,
+                                               StringPiece region, int32_t prefsOffset,
                                                int32_t prefsCount, UErrorCode &status) {
     this->category.append(category, status);
     this->usage.append(usage, status);
@@ -304,8 +304,8 @@ int32_t binarySearch(const MaybeStackVector<UnitPreferenceMetadata> *metadata,
  * preferences. If appropriate preferences are not found, -1 is returned.
  */
 int32_t getPreferenceMetadataIndex(const MaybeStackVector<UnitPreferenceMetadata> *metadata,
-                                   const StringPiece category, const StringPiece usage,
-                                   const StringPiece region, UErrorCode &status) {
+                                   StringPiece category, StringPiece usage, StringPiece region,
+                                   UErrorCode &status) {
     if (U_FAILURE(status)) { return -1; }
     bool foundCategory, foundUsage, foundRegion;
     UnitPreferenceMetadata desired(category, usage, region, -1, -1, status);
@@ -401,8 +401,8 @@ U_I18N_API UnitPreferences::UnitPreferences(UErrorCode &status) {
 //
 // TODO: consider replacing `UnitPreference **&outPrefrences` with slice class
 // of some kind.
-void U_I18N_API UnitPreferences::getPreferencesFor(const StringPiece category, const StringPiece usage,
-                                                   const StringPiece region,
+void U_I18N_API UnitPreferences::getPreferencesFor(StringPiece category, StringPiece usage,
+                                                   StringPiece region,
                                                    const UnitPreference *const *&outPreferences,
                                                    int32_t &preferenceCount, UErrorCode &status) const {
     int32_t idx = getPreferenceMetadataIndex(&metadata_, category, usage, region, status);

--- a/icu4c/source/i18n/unitsdata.cpp
+++ b/icu4c/source/i18n/unitsdata.cpp
@@ -107,8 +107,8 @@ class ConversionRateDataSink : public ResourceSink {
     MaybeStackVector<ConversionRateInfo> *outVector;
 };
 
-UnitPreferenceMetadata::UnitPreferenceMetadata(const char *category, const char *usage,
-                                               const char *region, int32_t prefsOffset,
+UnitPreferenceMetadata::UnitPreferenceMetadata(const StringPiece category, const StringPiece usage,
+                                               const StringPiece region, int32_t prefsOffset,
                                                int32_t prefsCount, UErrorCode &status) {
     this->category.append(category, status);
     this->usage.append(usage, status);
@@ -304,8 +304,8 @@ int32_t binarySearch(const MaybeStackVector<UnitPreferenceMetadata> *metadata,
  * preferences. If appropriate preferences are not found, -1 is returned.
  */
 int32_t getPreferenceMetadataIndex(const MaybeStackVector<UnitPreferenceMetadata> *metadata,
-                                   const char *category, const char *usage, const char *region,
-                                   UErrorCode &status) {
+                                   const StringPiece category, const StringPiece usage,
+                                   const StringPiece region, UErrorCode &status) {
     if (U_FAILURE(status)) { return -1; }
     bool foundCategory, foundUsage, foundRegion;
     UnitPreferenceMetadata desired(category, usage, region, -1, -1, status);
@@ -401,8 +401,8 @@ U_I18N_API UnitPreferences::UnitPreferences(UErrorCode &status) {
 //
 // TODO: consider replacing `UnitPreference **&outPrefrences` with slice class
 // of some kind.
-void U_I18N_API UnitPreferences::getPreferencesFor(const char *category, const char *usage,
-                                                   const char *region,
+void U_I18N_API UnitPreferences::getPreferencesFor(const StringPiece category, const StringPiece usage,
+                                                   const StringPiece region,
                                                    const UnitPreference *const *&outPreferences,
                                                    int32_t &preferenceCount, UErrorCode &status) const {
     int32_t idx = getPreferenceMetadataIndex(&metadata_, category, usage, region, status);

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -115,7 +115,7 @@ class U_I18N_API UnitPreferenceMetadata : public UMemory {
   public:
     UnitPreferenceMetadata(){};
     // Constructor, makes copies of the parameters passed to it.
-    UnitPreferenceMetadata(const StringPiece category, const StringPiece usage, const StringPiece region,
+    UnitPreferenceMetadata(StringPiece category, StringPiece usage, StringPiece region,
                            int32_t prefsOffset, int32_t prefsCount, UErrorCode &status);
 
     // Unit category (e.g. "length", "mass", "electric-capacitance").
@@ -177,7 +177,7 @@ class U_I18N_API UnitPreferences {
      *
      * TODO(hugovdm): maybe replace `UnitPreference **&outPrefrences` with a slice class?
      */
-    void getPreferencesFor(const StringPiece category, const StringPiece usage, const StringPiece region,
+    void getPreferencesFor(StringPiece category, StringPiece usage, StringPiece region,
                            const UnitPreference *const *&outPreferences, int32_t &preferenceCount,
                            UErrorCode &status) const;
 

--- a/icu4c/source/i18n/unitsdata.h
+++ b/icu4c/source/i18n/unitsdata.h
@@ -115,7 +115,7 @@ class U_I18N_API UnitPreferenceMetadata : public UMemory {
   public:
     UnitPreferenceMetadata(){};
     // Constructor, makes copies of the parameters passed to it.
-    UnitPreferenceMetadata(const char *category, const char *usage, const char *region,
+    UnitPreferenceMetadata(const StringPiece category, const StringPiece usage, const StringPiece region,
                            int32_t prefsOffset, int32_t prefsCount, UErrorCode &status);
 
     // Unit category (e.g. "length", "mass", "electric-capacitance").
@@ -177,7 +177,7 @@ class U_I18N_API UnitPreferences {
      *
      * TODO(hugovdm): maybe replace `UnitPreference **&outPrefrences` with a slice class?
      */
-    void getPreferencesFor(const char *category, const char *usage, const char *region,
+    void getPreferencesFor(const StringPiece category, const StringPiece usage, const StringPiece region,
                            const UnitPreference *const *&outPreferences, int32_t &preferenceCount,
                            UErrorCode &status) const;
 


### PR DESCRIPTION
This allows the function to accept not-null-terminated StringPiece instances.

In getPreferenceMetadataIndex() these get converted to CharStrings when constructing the UnitPreferenceMetadata instance, via CharString's StringPiece constructor.