### PR TITLE
Update supplementalData.txt and units.txt from upstream #1173

### DIFF
--- a/icu4c/source/data/misc/supplementalData.txt
+++ b/icu4c/source/data/misc/supplementalData.txt
@@ -2104,7 +2104,7 @@ supplementalData:table(nofallback){
             "islamic-tbla",
         }
     }
-    cldrVersion{"38"}
+    cldrVersion{"37"}
     codeMappings{
         {
             "AA",

--- a/icu4c/source/data/misc/supplementalData.txt
+++ b/icu4c/source/data/misc/supplementalData.txt
@@ -2104,7 +2104,7 @@ supplementalData:table(nofallback){
             "islamic-tbla",
         }
     }
-    cldrVersion{"37"}
+    cldrVersion{"38"}
     codeMappings{
         {
             "AA",

--- a/icu4c/source/data/misc/units.txt
+++ b/icu4c/source/data/misc/units.txt
@@ -1,7 +1,7 @@
 ﻿// © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html#License
 units:table(nofallback){
-    cldrVersion{"38"}
+    cldrVersion{"37"}
     convertUnits{
         100-kilometer{
             factor{"100000"}

--- a/icu4c/source/data/misc/units.txt
+++ b/icu4c/source/data/misc/units.txt
@@ -1,7 +1,7 @@
 ﻿// © 2016 and later: Unicode, Inc. and others.
 // License & terms of use: http://www.unicode.org/copyright.html#License
 units:table(nofallback){
-    cldrVersion{"37"}
+    cldrVersion{"38"}
     convertUnits{
         100-kilometer{
             factor{"100000"}
@@ -71,10 +71,6 @@ units:table(nofallback){
             factor{"1"}
             offset{"273.15"}
             target{"kelvin"}
-        }
-        centimeter{
-            factor{"1/100"}
-            target{"meter"}
         }
         century{
             factor{"100"}
@@ -1299,14 +1295,6 @@ units:table(nofallback){
                     }
                 }
                 SE{
-// Manual override of "SE road" preferences, to match what
-// unitPreferencesTest.txt claims should be produced.
-// CLDR:
-//                     {
-//                         geq{"0.1"}
-//                         unit{"mile-scandinavian"}
-//                     }
-// Overridden:
                     {
                         unit{"mile-scandinavian"}
                     }
@@ -1314,6 +1302,12 @@ units:table(nofallback){
                         unit{"kilometer"}
                     }
                     {
+                        geq{"300.0"}
+                        skeleton{"precision-increment/50"}
+                        unit{"meter"}
+                    }
+                    {
+                        skeleton{"precision-increment/10"}
                         unit{"meter"}
                     }
                 }


### PR DESCRIPTION
This grabs the output from an LdmlConverter run from this branch:
https://github.com/unicode-org/icu/pull/1173
(Once that branch is submitted, our resource file should automatically stay fresh when new CLDR data is imported.)

I'll take care of merging this into PR #30 if this PR gets submitted before that one. I tested already: post-merge, the unit tests all still pass, and units.txt diff should disappear from PR #30.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

